### PR TITLE
Add api-key based authentication for other services to authenticate as OpenSpending users

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,11 @@ OS_CHECK_ES_HEALTHY=
 # If using the fake-s3 docker container for development, openspending/fakes3, add these settings:
 USE_FAKE_S3=True
 OS_S3_PORT=4567
+
+# comma-separated list of colon-separated api key and user id to enable secret-based authentication.
+# API keys are strong secrets we make up for each client.
+# userids are the user id of the user seen in loca storage or URLs after a user logs in via Google OAuth.
+OS_CLIENT_API_KEYS=...apikey...:...userid...,...apikey2...:...userid2...
 ```
 
 ### OAuth Credentials

--- a/conductor/blueprints/user/blueprint.py
+++ b/conductor/blueprints/user/blueprint.py
@@ -1,7 +1,7 @@
 import os
 
 from flask import Blueprint, request, url_for, session
-from flask import make_response
+from flask import make_response, Response
 from flask import redirect
 from flask.ext.jsonpify import jsonpify
 
@@ -38,6 +38,14 @@ def create():
         return jsonpify(authenticate_controller(token, next_url,
                                                 get_callback_url()))
 
+    def authenticate_api_key():
+        api_key = request.headers.get('x-api-key')
+        resp = controllers.authenticate_api_key(api_key)
+        if resp:
+            return jsonpify(controllers.authenticate_api_key(api_key))
+        else:
+            return Response(response="Unauthorized", status=401)
+
     def update():
         token = request.values.get('jwt')
         username = request.values.get('username')
@@ -55,6 +63,8 @@ def create():
         'update', 'update', update, methods=['POST'])
     blueprint.add_url_rule(
         'authorize', 'authorize', authorize, methods=['GET'])
+    blueprint.add_url_rule(
+        'authenticate_api_key', 'authenticate_api_key', authenticate_api_key, methods=['POST'])
     blueprint.add_url_rule(
         'public-key', 'public-key', controllers.public_key, methods=['GET'])
     blueprint.add_url_rule(

--- a/conductor/blueprints/user/controllers.py
+++ b/conductor/blueprints/user/controllers.py
@@ -170,7 +170,7 @@ def authenticate_api_key(provided_key):
             auth_userid = userid
     if auth_userid and get_user(auth_userid):
         return {
-            "token": _create_client_token(auth_userid)
+            "token": _create_client_token(auth_userid).decode("utf-8")
         }
     else:
         return None

--- a/conductor/blueprints/user/controllers.py
+++ b/conductor/blueprints/user/controllers.py
@@ -4,6 +4,7 @@ import logging
 import json
 import base64
 import zlib
+from hmac import compare_digest
 
 try:
     import urllib.parse as urlparse
@@ -79,6 +80,15 @@ LIBJS = readfile_or_default(os.path.join(os.path.dirname(__file__),
 
 oauth = OAuth()
 
+# Client API keys in the form apikey:userid,apikey2,userid2
+# where apikey is some strong secret we make up, and userid is
+# the userid for a user who has authenticated via google
+# previously.
+API_KEYS = [
+    key_uid.split(":")
+    for key_uid in os.environ.get('OS_CLIENT_API_KEYS', "").split(",")
+]
+
 
 def _google_remote_app():
     if 'google' not in oauth.remote_apps:
@@ -152,6 +162,20 @@ def authenticate(token, next, callback_url):
     return ret
 
 
+def authenticate_api_key(provided_key):
+    # Always loop over all known keys to make timing attack a little harder
+    auth_userid = None
+    for key, userid in API_KEYS:
+        if compare_digest(provided_key, key):
+            auth_userid = userid
+    if auth_userid and get_user(auth_userid):
+        return {
+            "token": _create_client_token(auth_userid)
+        }
+    else:
+        return None
+
+
 def _update_next_url(next_url, client_token):
     if client_token is None:
         return next_url
@@ -175,8 +199,12 @@ def _get_token_from_profile(provider, profile):
     avatar_url = profile['picture']
     userid = '%s:%s' % (provider, provider_id)
     user = create_or_get_user(userid, name, email, avatar_url)
+    return _create_client_token(user['idhash'])
+
+
+def _create_client_token(userid):
     token = {
-        'userid': user['idhash'],
+        'userid': userid,
         'exp': (datetime.datetime.utcnow() +
                 datetime.timedelta(days=14))
     }


### PR DESCRIPTION
Adds the ability to configure API keys mapped to user IDs. Services can use an API key to impersonate a user and get a token as if they are the user who authenticated via Google OAuth